### PR TITLE
튜터 님 코드 리뷰 반영

### DIFF
--- a/app/src/main/java/com/dothebestmayb/nbc_applemarket/MainActivity.kt
+++ b/app/src/main/java/com/dothebestmayb/nbc_applemarket/MainActivity.kt
@@ -3,7 +3,6 @@ package com.dothebestmayb.nbc_applemarket
 import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.os.Bundle
-import android.util.Log
 import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.ViewCompat
@@ -48,18 +47,5 @@ class MainActivity : AppCompatActivity() {
         channel.description = descriptionText
         val notificationManager = getSystemService(NOTIFICATION_SERVICE) as NotificationManager
         notificationManager.createNotificationChannel(channel)
-    }
-
-    val TAG = MainActivity::class.java.simpleName
-    override fun onPause() {
-        super.onPause()
-
-        Log.i(TAG, "onPause is called")
-    }
-
-    override fun onStop() {
-        super.onStop()
-
-        Log.i(TAG, "onStop is called")
     }
 }

--- a/app/src/main/java/com/dothebestmayb/nbc_applemarket/MainActivity.kt
+++ b/app/src/main/java/com/dothebestmayb/nbc_applemarket/MainActivity.kt
@@ -8,7 +8,9 @@ import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
+import androidx.fragment.app.add
 import com.dothebestmayb.nbc_applemarket.databinding.ActivityMainBinding
+import com.dothebestmayb.nbc_applemarket.ui.main.MainPageFragment
 import com.dothebestmayb.nbc_applemarket.util.PRODUCT_NOTIFICATION_CHANNEL_ID
 
 class MainActivity : AppCompatActivity() {
@@ -26,7 +28,16 @@ class MainActivity : AppCompatActivity() {
             v.setPadding(systemBars.left, systemBars.top, systemBars.right, systemBars.bottom)
             insets
         }
+        setFragment(savedInstanceState)
         createNotificationChannel()
+    }
+
+    private fun setFragment(savedInstanceState: Bundle?) {
+        if (savedInstanceState == null) {
+            supportFragmentManager.beginTransaction()
+                .add<MainPageFragment>(R.id.fragment_container_view, MainPageFragment.MAIN_PAGE_FRAGMENT_TAG)
+                .commit()
+        }
     }
 
     private fun createNotificationChannel() {

--- a/app/src/main/java/com/dothebestmayb/nbc_applemarket/MainActivity.kt
+++ b/app/src/main/java/com/dothebestmayb/nbc_applemarket/MainActivity.kt
@@ -3,6 +3,7 @@ package com.dothebestmayb.nbc_applemarket
 import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.os.Bundle
+import android.util.Log
 import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.ViewCompat
@@ -36,5 +37,18 @@ class MainActivity : AppCompatActivity() {
         channel.description = descriptionText
         val notificationManager = getSystemService(NOTIFICATION_SERVICE) as NotificationManager
         notificationManager.createNotificationChannel(channel)
+    }
+
+    val TAG = MainActivity::class.java.simpleName
+    override fun onPause() {
+        super.onPause()
+
+        Log.i(TAG, "onPause is called")
+    }
+
+    override fun onStop() {
+        super.onStop()
+
+        Log.i(TAG, "onStop is called")
     }
 }

--- a/app/src/main/java/com/dothebestmayb/nbc_applemarket/MainActivity.kt
+++ b/app/src/main/java/com/dothebestmayb/nbc_applemarket/MainActivity.kt
@@ -3,12 +3,14 @@ package com.dothebestmayb.nbc_applemarket
 import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.os.Bundle
+import android.view.MotionEvent
 import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.fragment.app.add
 import com.dothebestmayb.nbc_applemarket.databinding.ActivityMainBinding
+import com.dothebestmayb.nbc_applemarket.ui.detail.DetailPageFragment
 import com.dothebestmayb.nbc_applemarket.ui.main.MainPageFragment
 import com.dothebestmayb.nbc_applemarket.util.PRODUCT_NOTIFICATION_CHANNEL_ID
 
@@ -47,5 +49,26 @@ class MainActivity : AppCompatActivity() {
         channel.description = descriptionText
         val notificationManager = getSystemService(NOTIFICATION_SERVICE) as NotificationManager
         notificationManager.createNotificationChannel(channel)
+    }
+
+    override fun dispatchTouchEvent(ev: MotionEvent?): Boolean {
+        if (ev == null) {
+            return super.dispatchTouchEvent(ev)
+        }
+
+        val fragment = supportFragmentManager.fragments.lastOrNull() ?: run {
+            return super.dispatchTouchEvent(ev)
+        }
+        // 태그를 이용해서 상세 화면인지 판별하기
+        return when (fragment.tag) {
+            DetailPageFragment.DETAIL_PAGE_FRAGMENT_TAG -> {
+                if ((fragment as DetailPageFragment).dispatchTouchEvent(ev)) {
+                    true
+                } else {
+                    super.dispatchTouchEvent(ev)
+                }
+            }
+            else -> super.dispatchTouchEvent(ev)
+        }
     }
 }

--- a/app/src/main/java/com/dothebestmayb/nbc_applemarket/model/Product.kt
+++ b/app/src/main/java/com/dothebestmayb/nbc_applemarket/model/Product.kt
@@ -38,7 +38,9 @@ data class Product(
 
         @Volatile
         private var count = 0
-            get() = field++
+            get() = synchronized(Product::class) {
+                field++
+            }
 
         private val dummyData = listOf(
             Product(

--- a/app/src/main/java/com/dothebestmayb/nbc_applemarket/model/ProductChangePayload.kt
+++ b/app/src/main/java/com/dothebestmayb/nbc_applemarket/model/ProductChangePayload.kt
@@ -1,5 +1,5 @@
 package com.dothebestmayb.nbc_applemarket.model
 
 enum class ProductChangePayload {
-    LIKE, LIKED_FILLED, LISTENER
+    LIKE, LIKED_FILLED
 }

--- a/app/src/main/java/com/dothebestmayb/nbc_applemarket/ui/detail/DetailPageFragment.kt
+++ b/app/src/main/java/com/dothebestmayb/nbc_applemarket/ui/detail/DetailPageFragment.kt
@@ -9,6 +9,7 @@ import android.view.MotionEvent
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Toast
+import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.commit
 import androidx.lifecycle.Lifecycle
@@ -155,23 +156,26 @@ class DetailPageFragment : Fragment() {
             vGuidance.root.visibility = View.GONE
         }
 
-        // 스크롤뷰를 클릭하면 매너 온도 안내 팝업이 사라지도록 구현
-        sv.setOnTouchListener { v, event ->
-            if (event.action == MotionEvent.ACTION_DOWN) {
-                vGuidance.root.visibility = View.GONE
-            }
-            false // 클릭되었을 때, 매너 온도 안내 팝업을 사라지도록 하는 것이 목표 이므로, 터치 이벤트가 child로 타고 가도록 false 처리
-        }
-
-        // 스크롤뷰에 등록한 터치 리스너로 인해, 매너 온도 안내 팝업을 클릭하면 사라지고 있는데, 이것을 방지하기 위한 코드
-        vGuidance.root.setOnTouchListener { v, event ->
-            true
-        }
-
         btnChat.setOnClickListener {
             Toast.makeText(requireContext(), R.string.chat_is_not_supported, Toast.LENGTH_SHORT)
                 .show()
         }
+    }
+
+    fun dispatchTouchEvent(event: MotionEvent): Boolean {
+        val guidanceView = binding.vGuidance.root
+        if (guidanceView.isVisible && isWithoutViewBounds(guidanceView, event.rawY, event.rawX)) {
+            guidanceView.visibility = View.GONE
+        }
+
+        return false
+    }
+
+    private fun isWithoutViewBounds(view: View, yPoint: Float, xPoint: Float): Boolean {
+        val xy = IntArray(2)
+        view.getLocationOnScreen(xy)
+        val (x, y) = xy
+        return xPoint < x || xPoint > x + view.width || yPoint < y || yPoint > y + view.height
     }
 
 
@@ -183,5 +187,6 @@ class DetailPageFragment : Fragment() {
 
     companion object {
         const val BUNDLE_KEY_FOR_PRODUCT = "BUNDLE_KEY_FOR_PRODUCT"
+        const val DETAIL_PAGE_FRAGMENT_TAG = "DETAIL_PAGE_FRAGMENT"
     }
 }

--- a/app/src/main/java/com/dothebestmayb/nbc_applemarket/ui/detail/DetailPageFragment.kt
+++ b/app/src/main/java/com/dothebestmayb/nbc_applemarket/ui/detail/DetailPageFragment.kt
@@ -10,6 +10,8 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.Toast
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.commit
+import androidx.lifecycle.Lifecycle
 import com.dothebestmayb.nbc_applemarket.R
 import com.dothebestmayb.nbc_applemarket.data.LikeManager
 import com.dothebestmayb.nbc_applemarket.data.LoggedUserManager
@@ -19,6 +21,7 @@ import com.dothebestmayb.nbc_applemarket.databinding.FragmentDetailPageBinding
 import com.dothebestmayb.nbc_applemarket.model.Product
 import com.dothebestmayb.nbc_applemarket.model.User
 import com.dothebestmayb.nbc_applemarket.model.UserTemperature
+import com.dothebestmayb.nbc_applemarket.ui.main.MainPageFragment
 import com.dothebestmayb.nbc_applemarket.util.toStringWithComma
 import com.google.android.material.snackbar.Snackbar
 
@@ -125,6 +128,14 @@ class DetailPageFragment : Fragment() {
     @SuppressLint("ClickableViewAccessibility")
     private fun setListener() = with(binding) {
         ibBack.setOnClickListener {
+            val mainPageFragment =
+                parentFragmentManager.findFragmentByTag(MainPageFragment.MAIN_PAGE_FRAGMENT_TAG)
+            if (mainPageFragment != null) {
+                parentFragmentManager.commit {
+                    show(mainPageFragment)
+                    setMaxLifecycle(mainPageFragment, Lifecycle.State.RESUMED)
+                }
+            }
             parentFragmentManager.popBackStack()
         }
         ivLike.setOnClickListener {
@@ -158,7 +169,8 @@ class DetailPageFragment : Fragment() {
         }
 
         btnChat.setOnClickListener {
-            Toast.makeText(requireContext(), R.string.chat_is_not_supported, Toast.LENGTH_SHORT).show()
+            Toast.makeText(requireContext(), R.string.chat_is_not_supported, Toast.LENGTH_SHORT)
+                .show()
         }
     }
 

--- a/app/src/main/java/com/dothebestmayb/nbc_applemarket/ui/detail/DetailPageFragment.kt
+++ b/app/src/main/java/com/dothebestmayb/nbc_applemarket/ui/detail/DetailPageFragment.kt
@@ -153,8 +153,8 @@ class DetailPageFragment : Fragment() {
         }
 
         // 스크롤뷰에 등록한 터치 리스너로 인해, 매너 온도 안내 팝업을 클릭하면 사라지고 있는데, 이것을 방지하기 위한 코드
-        vGuidance.root.setOnClickListener {
-            it.visibility = View.VISIBLE
+        vGuidance.root.setOnTouchListener { v, event ->
+            true
         }
 
         btnChat.setOnClickListener {

--- a/app/src/main/java/com/dothebestmayb/nbc_applemarket/ui/main/MainPageFragment.kt
+++ b/app/src/main/java/com/dothebestmayb/nbc_applemarket/ui/main/MainPageFragment.kt
@@ -106,7 +106,6 @@ class MainPageFragment : Fragment(), ProductOnClickListener, LocationOnClickList
             add(R.id.fragment_container_view, fragment, DetailPageFragment.DETAIL_PAGE_FRAGMENT_TAG)
             setReorderingAllowed(true)
             addToBackStack(null)
-            setMaxLifecycle(fragment, Lifecycle.State.RESUMED)
         }
     }
 

--- a/app/src/main/java/com/dothebestmayb/nbc_applemarket/ui/main/MainPageFragment.kt
+++ b/app/src/main/java/com/dothebestmayb/nbc_applemarket/ui/main/MainPageFragment.kt
@@ -13,6 +13,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.view.animation.AccelerateInterpolator
+import androidx.activity.OnBackPressedCallback
 import androidx.activity.addCallback
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AlertDialog
@@ -135,7 +136,7 @@ class MainPageFragment : Fragment(), ProductOnClickListener, LocationOnClickList
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        requireActivity().onBackPressedDispatcher.addCallback(this) {
+        requireActivity().onBackPressedDispatcher.addCallback(visibleLifecycleOwner) {
             if (isEnabled) {
                 finishDialog.show()
             }

--- a/app/src/main/java/com/dothebestmayb/nbc_applemarket/ui/main/MainPageFragment.kt
+++ b/app/src/main/java/com/dothebestmayb/nbc_applemarket/ui/main/MainPageFragment.kt
@@ -2,6 +2,7 @@ package com.dothebestmayb.nbc_applemarket.ui.main
 
 import android.Manifest
 import android.app.NotificationManager
+import android.content.Context
 import android.content.DialogInterface
 import android.content.Intent
 import android.content.pm.PackageManager
@@ -9,6 +10,7 @@ import android.net.Uri
 import android.os.Build
 import android.os.Bundle
 import android.provider.Settings
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -180,12 +182,15 @@ class MainPageFragment : Fragment(), ProductOnClickListener, LocationOnClickList
             }
         }
         insertDummyData()
+        Log.i(TAG, "onCreate is called")
     }
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
+        Log.i(TAG, "onCreateView is called")
+
         _binding = FragmentMainPageBinding.inflate(inflater, container, false)
         return binding.root
     }
@@ -193,6 +198,7 @@ class MainPageFragment : Fragment(), ProductOnClickListener, LocationOnClickList
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
+        Log.i(TAG, "onViewCreated is called")
         setRecyclerView()
         setListener()
     }
@@ -280,10 +286,47 @@ class MainPageFragment : Fragment(), ProductOnClickListener, LocationOnClickList
         UserManager.addUser(User.getDummyData())
     }
 
+    override fun onPause() {
+        super.onPause()
+
+        Log.i(TAG, "onPause is called")
+    }
+    override fun onStop() {
+        super.onStop()
+
+        Log.i(TAG, "onStop called")
+    }
+
+    override fun onResume() {
+        super.onResume()
+
+        Log.i(TAG, "onResume called")
+    }
+
     override fun onDestroy() {
         _binding = null
 
         super.onDestroy()
+        Log.i(TAG, "onDestroy called")
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        Log.i(TAG, "onDestroyView is called")
+    }
+
+    val TAG = MainPageFragment::class.java.simpleName
+
+    override fun onAttach(context: Context) {
+        super.onAttach(context)
+
+        Log.i(TAG, "onAttach called")
+    }
+
+    override fun onDetach() {
+        super.onDetach()
+
+        Log.i(TAG, "onDetach called")
     }
 
 }

--- a/app/src/main/java/com/dothebestmayb/nbc_applemarket/ui/main/MainPageFragment.kt
+++ b/app/src/main/java/com/dothebestmayb/nbc_applemarket/ui/main/MainPageFragment.kt
@@ -2,7 +2,6 @@ package com.dothebestmayb.nbc_applemarket.ui.main
 
 import android.Manifest
 import android.app.NotificationManager
-import android.content.Context
 import android.content.DialogInterface
 import android.content.Intent
 import android.content.pm.PackageManager
@@ -46,7 +45,7 @@ class MainPageFragment : Fragment(), ProductOnClickListener, LocationOnClickList
 
     private lateinit var productWillBeDeleted: Product
 
-    private lateinit var builder: NotificationCompat.Builder
+    private lateinit var notificationBuilder: NotificationCompat.Builder
 
     private lateinit var notificationPermissionDialog: AlertDialog.Builder
     private lateinit var notificationChannelPermissionDialog: AlertDialog.Builder
@@ -178,12 +177,13 @@ class MainPageFragment : Fragment(), ProductOnClickListener, LocationOnClickList
     }
 
     private fun setNotification() {
-        builder = NotificationCompat.Builder(requireContext(), PRODUCT_NOTIFICATION_CHANNEL_ID)
-            .setSmallIcon(R.drawable.carrot)
-            .setContentTitle(getString(R.string.product_notification_alert_title))
-            .setContentText(getString(R.string.product_notification_alert_message))
-            .setPriority(NotificationCompat.PRIORITY_DEFAULT)
-            .setColor(resources.getColor(R.color.primary, requireContext().theme))
+        notificationBuilder =
+            NotificationCompat.Builder(requireContext(), PRODUCT_NOTIFICATION_CHANNEL_ID)
+                .setSmallIcon(R.drawable.carrot)
+                .setContentTitle(getString(R.string.product_notification_alert_title))
+                .setContentText(getString(R.string.product_notification_alert_message))
+                .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+                .setColor(resources.getColor(R.color.primary, requireContext().theme))
     }
 
     override fun onCreateView(
@@ -275,7 +275,7 @@ class MainPageFragment : Fragment(), ProductOnClickListener, LocationOnClickList
             return
         }
         NotificationManagerCompat.from(requireContext())
-            .notify(PRODUCT_NOTIFICATION_ID, builder.build())
+            .notify(PRODUCT_NOTIFICATION_ID, notificationBuilder.build())
 
     }
 

--- a/app/src/main/java/com/dothebestmayb/nbc_applemarket/ui/main/MainPageFragment.kt
+++ b/app/src/main/java/com/dothebestmayb/nbc_applemarket/ui/main/MainPageFragment.kt
@@ -13,7 +13,6 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.view.animation.AccelerateInterpolator
-import androidx.activity.OnBackPressedCallback
 import androidx.activity.addCallback
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AlertDialog
@@ -104,7 +103,7 @@ class MainPageFragment : Fragment(), ProductOnClickListener, LocationOnClickList
                 arguments = bundle
             }
 
-            add(R.id.fragment_container_view, fragment)
+            add(R.id.fragment_container_view, fragment, DetailPageFragment.DETAIL_PAGE_FRAGMENT_TAG)
             setReorderingAllowed(true)
             addToBackStack(null)
             setMaxLifecycle(fragment, Lifecycle.State.RESUMED)

--- a/app/src/main/java/com/dothebestmayb/nbc_applemarket/ui/main/MainPageFragment.kt
+++ b/app/src/main/java/com/dothebestmayb/nbc_applemarket/ui/main/MainPageFragment.kt
@@ -10,7 +10,6 @@ import android.net.Uri
 import android.os.Build
 import android.os.Bundle
 import android.provider.Settings
-import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -126,7 +125,6 @@ class MainPageFragment : Fragment(), ProductOnClickListener, LocationOnClickList
         insertDummyData()
         createAlertDialog()
         setNotification()
-        Log.i(TAG, "onCreate is called")
     }
 
     private fun createAlertDialog() {
@@ -192,8 +190,6 @@ class MainPageFragment : Fragment(), ProductOnClickListener, LocationOnClickList
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
-        Log.i(TAG, "onCreateView is called")
-
         _binding = FragmentMainPageBinding.inflate(inflater, container, false)
         return binding.root
     }
@@ -201,7 +197,6 @@ class MainPageFragment : Fragment(), ProductOnClickListener, LocationOnClickList
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        Log.i(TAG, "onViewCreated is called")
         setRecyclerView()
         setListener()
     }
@@ -288,49 +283,4 @@ class MainPageFragment : Fragment(), ProductOnClickListener, LocationOnClickList
         ProductManager.addProduct(Product.getDummyData())
         UserManager.addUser(User.getDummyData())
     }
-
-    override fun onPause() {
-        super.onPause()
-
-        Log.i(TAG, "onPause is called")
-    }
-
-    override fun onStop() {
-        super.onStop()
-
-        Log.i(TAG, "onStop called")
-    }
-
-    override fun onResume() {
-        super.onResume()
-
-        Log.i(TAG, "onResume called")
-    }
-
-    override fun onDestroy() {
-        _binding = null
-
-        super.onDestroy()
-        Log.i(TAG, "onDestroy called")
-    }
-
-    override fun onDestroyView() {
-        super.onDestroyView()
-        Log.i(TAG, "onDestroyView is called")
-    }
-
-    val TAG = MainPageFragment::class.java.simpleName
-
-    override fun onAttach(context: Context) {
-        super.onAttach(context)
-
-        Log.i(TAG, "onAttach called")
-    }
-
-    override fun onDetach() {
-        super.onDetach()
-
-        Log.i(TAG, "onDetach called")
-    }
-
 }

--- a/app/src/main/java/com/dothebestmayb/nbc_applemarket/ui/main/MainPageFragment.kt
+++ b/app/src/main/java/com/dothebestmayb/nbc_applemarket/ui/main/MainPageFragment.kt
@@ -47,43 +47,12 @@ class MainPageFragment : Fragment(), ProductOnClickListener, LocationOnClickList
 
     private lateinit var productWillBeDeleted: Product
 
-    private val builder by lazy {
-        NotificationCompat.Builder(requireContext(), PRODUCT_NOTIFICATION_CHANNEL_ID)
-            .setSmallIcon(R.drawable.carrot)
-            .setContentTitle(getString(R.string.product_notification_alert_title))
-            .setContentText(getString(R.string.product_notification_alert_message))
-            .setPriority(NotificationCompat.PRIORITY_DEFAULT)
-            .setColor(resources.getColor(R.color.primary, requireContext().theme))
-    }
+    private lateinit var builder: NotificationCompat.Builder
 
-    private val notificationPermissionDialog by lazy {
-        AlertDialog.Builder(requireContext())
-            .setTitle(getString(R.string.notification_permission_title))
-            .setMessage(getString(R.string.notification_permission_message))
-            .setNegativeButton(getString(R.string.permission_negative)) { _: DialogInterface, _: Int ->
-            }
-            .setPositiveButton(getString(R.string.permission_positive)) { _, _ ->
-                val intent = Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS).apply {
-                    data = Uri.parse("package:" + requireContext().packageName)
-                }
-                startActivity(intent)
-            }
-    }
-
-    private val notificationChannelPermissionDialog by lazy {
-        AlertDialog.Builder(requireContext())
-            .setTitle(getString(R.string.product_channel_permission_title))
-            .setMessage(getString(R.string.product_channel_permission_message))
-            .setNegativeButton(getString(R.string.permission_negative)) { _: DialogInterface, _: Int ->
-            }
-            .setPositiveButton(getString(R.string.permission_positive)) { _, _ ->
-                val intent = Intent(Settings.ACTION_CHANNEL_NOTIFICATION_SETTINGS).apply {
-                    putExtra(Settings.EXTRA_APP_PACKAGE, requireContext().packageName)
-                    putExtra(Settings.EXTRA_CHANNEL_ID, PRODUCT_NOTIFICATION_CHANNEL_ID)
-                }
-                startActivity(intent)
-            }
-    }
+    private lateinit var notificationPermissionDialog: AlertDialog.Builder
+    private lateinit var notificationChannelPermissionDialog: AlertDialog.Builder
+    private lateinit var finishDialog: AlertDialog.Builder
+    private lateinit var deleteDialog: AlertDialog.Builder
 
     private val requestPermissionLauncher =
         registerForActivityResult(ActivityResultContracts.RequestPermission()) { isGranted ->
@@ -95,35 +64,8 @@ class MainPageFragment : Fragment(), ProductOnClickListener, LocationOnClickList
             }
         }
 
-    private val productAdapter by lazy { ProductAdapter(this) }
-    private val locationAdapter by lazy { LocationAdapter(this) }
-
-    private val finishDialog by lazy {
-        AlertDialog.Builder(requireContext())
-            .setTitle(getString(R.string.finish_dialog_title))
-            .setMessage(getString(R.string.finish_dialog_message))
-            .setIcon(R.drawable.conversation)
-            .setNegativeButton(resources.getString(R.string.decline)) { _, _ ->
-
-            }
-            .setPositiveButton(resources.getString(R.string.accept)) { _, _ ->
-                requireActivity().finish()
-            }
-    }
-
-    private val deleteDialog by lazy {
-        AlertDialog.Builder(requireContext())
-            .setTitle(getString(R.string.delete_dialog_title))
-            .setMessage(getString(R.string.delete_dialog_message))
-            .setIcon(R.drawable.conversation)
-            .setNegativeButton(resources.getString(R.string.decline)) { _, _ ->
-
-            }
-            .setPositiveButton(resources.getString(R.string.accept)) { _, _ ->
-                ProductManager.removeProduct(productWillBeDeleted)
-                updateProductList()
-            }
-    }
+    private val productAdapter = ProductAdapter(this)
+    private val locationAdapter = LocationAdapter(this)
 
     private fun updateProductList() {
         val products = ProductManager.getAllProducts()
@@ -182,7 +124,68 @@ class MainPageFragment : Fragment(), ProductOnClickListener, LocationOnClickList
             }
         }
         insertDummyData()
+        createAlertDialog()
+        setNotification()
         Log.i(TAG, "onCreate is called")
+    }
+
+    private fun createAlertDialog() {
+        notificationPermissionDialog = AlertDialog.Builder(requireContext())
+            .setTitle(getString(R.string.notification_permission_title))
+            .setMessage(getString(R.string.notification_permission_message))
+            .setNegativeButton(getString(R.string.permission_negative)) { _: DialogInterface, _: Int ->
+            }
+            .setPositiveButton(getString(R.string.permission_positive)) { _, _ ->
+                val intent = Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS).apply {
+                    data = Uri.parse("package:" + requireContext().packageName)
+                }
+                startActivity(intent)
+            }
+        notificationChannelPermissionDialog = AlertDialog.Builder(requireContext())
+            .setTitle(getString(R.string.product_channel_permission_title))
+            .setMessage(getString(R.string.product_channel_permission_message))
+            .setNegativeButton(getString(R.string.permission_negative)) { _: DialogInterface, _: Int ->
+            }
+            .setPositiveButton(getString(R.string.permission_positive)) { _, _ ->
+                val intent = Intent(Settings.ACTION_CHANNEL_NOTIFICATION_SETTINGS).apply {
+                    putExtra(Settings.EXTRA_APP_PACKAGE, requireContext().packageName)
+                    putExtra(Settings.EXTRA_CHANNEL_ID, PRODUCT_NOTIFICATION_CHANNEL_ID)
+                }
+                startActivity(intent)
+            }
+
+
+        finishDialog = AlertDialog.Builder(requireContext())
+            .setTitle(getString(R.string.finish_dialog_title))
+            .setMessage(getString(R.string.finish_dialog_message))
+            .setIcon(R.drawable.conversation)
+            .setNegativeButton(resources.getString(R.string.decline)) { _, _ ->
+
+            }
+            .setPositiveButton(resources.getString(R.string.accept)) { _, _ ->
+                requireActivity().finish()
+            }
+
+        deleteDialog = AlertDialog.Builder(requireContext())
+            .setTitle(getString(R.string.delete_dialog_title))
+            .setMessage(getString(R.string.delete_dialog_message))
+            .setIcon(R.drawable.conversation)
+            .setNegativeButton(resources.getString(R.string.decline)) { _, _ ->
+
+            }
+            .setPositiveButton(resources.getString(R.string.accept)) { _, _ ->
+                ProductManager.removeProduct(productWillBeDeleted)
+                updateProductList()
+            }
+    }
+
+    private fun setNotification() {
+        builder = NotificationCompat.Builder(requireContext(), PRODUCT_NOTIFICATION_CHANNEL_ID)
+            .setSmallIcon(R.drawable.carrot)
+            .setContentTitle(getString(R.string.product_notification_alert_title))
+            .setContentText(getString(R.string.product_notification_alert_message))
+            .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+            .setColor(resources.getColor(R.color.primary, requireContext().theme))
     }
 
     override fun onCreateView(
@@ -291,6 +294,7 @@ class MainPageFragment : Fragment(), ProductOnClickListener, LocationOnClickList
 
         Log.i(TAG, "onPause is called")
     }
+
     override fun onStop() {
         super.onStop()
 

--- a/app/src/main/java/com/dothebestmayb/nbc_applemarket/ui/main/MainPageFragment.kt
+++ b/app/src/main/java/com/dothebestmayb/nbc_applemarket/ui/main/MainPageFragment.kt
@@ -23,6 +23,8 @@ import androidx.core.app.NotificationManagerCompat
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.commit
 import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.LifecycleOwner
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.dothebestmayb.nbc_applemarket.R
@@ -43,6 +45,10 @@ class MainPageFragment : Fragment(), ProductOnClickListener, LocationOnClickList
     private var _binding: FragmentMainPageBinding? = null
     private val binding: FragmentMainPageBinding
         get() = _binding!!
+
+    private val visibleLifecycleOwner: SimpleLifecycleOwner by lazy {
+        SimpleLifecycleOwner()
+    }
 
     private lateinit var productWillBeDeleted: Product
 
@@ -210,8 +216,28 @@ class MainPageFragment : Fragment(), ProductOnClickListener, LocationOnClickList
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
+        setLifecycle()
         setRecyclerView()
         setListener()
+    }
+
+    private fun setLifecycle() {
+        viewLifecycleOwner.lifecycle.addObserver(object : LifecycleEventObserver {
+            override fun onStateChanged(source: LifecycleOwner, event: Lifecycle.Event) {
+                when (event) {
+                    Lifecycle.Event.ON_RESUME, Lifecycle.Event.ON_PAUSE -> {
+                        if (isHidden) {
+                            visibleLifecycleOwner.handleLifecycleEvent(Lifecycle.Event.ON_STOP)
+                        } else {
+                            visibleLifecycleOwner.handleLifecycleEvent(event)
+                        }
+                    }
+
+                    else -> visibleLifecycleOwner.handleLifecycleEvent(event)
+                }
+            }
+
+        })
     }
 
     private fun setRecyclerView() {

--- a/app/src/main/java/com/dothebestmayb/nbc_applemarket/ui/main/MainPageFragment.kt
+++ b/app/src/main/java/com/dothebestmayb/nbc_applemarket/ui/main/MainPageFragment.kt
@@ -22,6 +22,7 @@ import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.commit
+import androidx.lifecycle.Lifecycle
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.dothebestmayb.nbc_applemarket.R
@@ -84,6 +85,10 @@ class MainPageFragment : Fragment(), ProductOnClickListener, LocationOnClickList
 
     override fun onClick(product: Product) {
         parentFragmentManager.commit {
+            if (this@MainPageFragment.isVisible) {
+                hide(this@MainPageFragment)
+                setMaxLifecycle(this@MainPageFragment, Lifecycle.State.STARTED)
+            }
 
             val bundle = Bundle().apply {
                 putParcelable(DetailPageFragment.BUNDLE_KEY_FOR_PRODUCT, product)
@@ -91,10 +96,18 @@ class MainPageFragment : Fragment(), ProductOnClickListener, LocationOnClickList
             val fragment = DetailPageFragment().apply {
                 arguments = bundle
             }
-            replace(R.id.fragment_container_view, fragment)
+
+            add(R.id.fragment_container_view, fragment)
             setReorderingAllowed(true)
             addToBackStack(null)
+            setMaxLifecycle(fragment, Lifecycle.State.RESUMED)
         }
+    }
+
+    override fun onResume() {
+        super.onResume()
+
+        updateProductList()
     }
 
     override fun onClick(location: LocationItem) {
@@ -282,5 +295,15 @@ class MainPageFragment : Fragment(), ProductOnClickListener, LocationOnClickList
     private fun insertDummyData() {
         ProductManager.addProduct(Product.getDummyData())
         UserManager.addUser(User.getDummyData())
+    }
+
+    override fun onDestroyView() {
+        _binding = null
+
+        super.onDestroyView()
+    }
+
+    companion object {
+        const val MAIN_PAGE_FRAGMENT_TAG = "mainPageFragment"
     }
 }

--- a/app/src/main/java/com/dothebestmayb/nbc_applemarket/ui/main/ProductAdapter.kt
+++ b/app/src/main/java/com/dothebestmayb/nbc_applemarket/ui/main/ProductAdapter.kt
@@ -56,6 +56,7 @@ class ProductAdapter(
         }
 
         fun updateLikeFilled(product: Product) {
+            this.product = product
             val id = if (LikeManager.checkLike(LoggedUserManager.getUserInfo(), product)) {
                 R.drawable.like_fill
             } else {

--- a/app/src/main/java/com/dothebestmayb/nbc_applemarket/ui/main/ProductAdapter.kt
+++ b/app/src/main/java/com/dothebestmayb/nbc_applemarket/ui/main/ProductAdapter.kt
@@ -18,13 +18,32 @@ class ProductAdapter(
     private val onClickListener: ProductOnClickListener,
 ) : ListAdapter<Product, ProductAdapter.ViewHolder>(diffCallback) {
 
-    inner class ViewHolder(private val binding: ItemProductOverviewBinding) :
+    class ViewHolder(
+        private val binding: ItemProductOverviewBinding,
+        private val onClickListener: ProductOnClickListener,
+    ) :
         RecyclerView.ViewHolder(binding.root) {
 
+        private var product: Product? = null
+
+        init {
+            binding.root.setOnClickListener {
+                product?.let {
+                    onClickListener.onClick(it)
+                }
+            }
+            binding.root.setOnLongClickListener {
+                product?.let {
+                    onClickListener.onLongClick(it)
+                }
+                return@setOnLongClickListener true
+            }
+        }
+
         fun bind(product: Product) = with(binding) {
+            this@ViewHolder.product = product
             setData(product)
             setVisibility(product)
-            setListener(product)
         }
 
         private fun setData(product: Product) = with(binding) {
@@ -65,16 +84,6 @@ class ProductAdapter(
             ivChat.visibility = likeVisibility
         }
 
-        fun setListener(product: Product) {
-            binding.root.setOnClickListener {
-                onClickListener.onClick(product)
-            }
-            binding.root.setOnLongClickListener {
-                onClickListener.onLongClick(product)
-                return@setOnLongClickListener true
-            }
-        }
-
         fun updateLike(count: Int) {
             binding.tvLike.text = count.toString()
         }
@@ -82,7 +91,8 @@ class ProductAdapter(
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
         return ViewHolder(
-            ItemProductOverviewBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+            ItemProductOverviewBinding.inflate(LayoutInflater.from(parent.context), parent, false),
+            onClickListener,
         )
     }
 
@@ -101,7 +111,6 @@ class ProductAdapter(
                 when (payload) {
                     ProductChangePayload.LIKE -> holder.updateLike(product.like)
                     ProductChangePayload.LIKED_FILLED -> holder.updateLikeFilled(product)
-                    ProductChangePayload.LISTENER -> holder.setListener(product)
                 }
             }
         }
@@ -124,7 +133,6 @@ class ProductAdapter(
                 if (oldItem.like != newItem.like) {
                     changes.add(ProductChangePayload.LIKE)
                     changes.add(ProductChangePayload.LIKED_FILLED)
-                    changes.add(ProductChangePayload.LISTENER)
                 }
 
                 return changes

--- a/app/src/main/java/com/dothebestmayb/nbc_applemarket/ui/main/SimpleLifecycleOwner.kt
+++ b/app/src/main/java/com/dothebestmayb/nbc_applemarket/ui/main/SimpleLifecycleOwner.kt
@@ -1,0 +1,16 @@
+package com.dothebestmayb.nbc_applemarket.ui.main
+
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.LifecycleRegistry
+
+class SimpleLifecycleOwner: LifecycleOwner {
+    private val _lifecycle = LifecycleRegistry(this)
+
+    override val lifecycle: Lifecycle
+        get() = _lifecycle
+
+    fun handleLifecycleEvent(event: Lifecycle.Event) {
+        _lifecycle.handleLifecycleEvent(event)
+    }
+}

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -8,12 +8,12 @@
 
     <androidx.fragment.app.FragmentContainerView
         android:id="@+id/fragment_container_view"
-        android:name="com.dothebestmayb.nbc_applemarket.ui.main.MainPageFragment"
         android:layout_width="0dp"
         android:layout_height="0dp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintTop_toTopOf="parent"
+        tools:name="com.dothebestmayb.nbc_applemarket.ui.main.MainPageFragment" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
## 1차 피드백 주신 부분 반영 커밋
- by lazy로 인한 불필요한 전역코드들 -> 불필요한 전역변수들은 지역변수로 바꾸고 by lazy가 꼭 필요한게 아니라면 다른방법으로 초기화 하는것이 좋습니다.(성능저하)
[refactor: 가능한 lazy를 사용하지 않도록 수정](https://github.com/DoTheBestMayB/NBC-AppleMarket/pull/1/commits/b48f2ab7f68afa1231b88f4d1c7f278ad86ba862)
- private val builder by lazy {  이부분은 builder보다는 의미있는 이름을 주는것이 좋겠습니다.
[chore: 알림 Builder 변수 이름 명확하게 수정](https://github.com/DoTheBestMayB/NBC-AppleMarket/pull/1/commits/ecf6a3d028a0412d2b8592e2226c2beb1dee4957)

> ```kotlin
> sv.setOnTouchListener { v, event ->
>     if (event.action == MotionEvent.ACTION_DOWN) {
>         vGuidance.root.visibility = View.GONE
>     }
> 
>     false //*****여기서 이렇게 했으니
> }
> 
> // 스크롤뷰에 등록한 터치 리스너로 인해, 매너 온도 안내 팝업을 클릭하면 사라지고 있는데, 이것을 방지하기 위한 코드
> vGuidance.root.setOnClickListener {
>     //it.visibility = View.VISIBLE
>     true //******여기서도 이렇게 하면 되지 않을까요?
> }
> ```

[refactor: 온도안내 팝업 사라지는 거 방지하기 위한 코드 로직 수정](https://github.com/DoTheBestMayB/NBC-AppleMarket/pull/1/commits/533fb08de1248bf90a10a556fef3557d06cb9a7f)


- count 변수에 @Volatile 은 의미가 없어보입니다.
보통 Volatile은 멀티스레드 환경에서 synchronized 등의 동기화와 같이 사용합니다.(가시성확보를위해)
[refactor: Product 클래스를 구분하는 uuid를 멀티쓰레딩 환경에서 중복되지 않게 생성하도록 synchroniz…](https://github.com/DoTheBestMayB/NBC-AppleMarket/pull/1/commits/9e92e3b383c0dea7881c836cebe0be5602450d6e)

## 2차 피드백 주신 부분 반영 커밋
- Q1. MainPageFragment에서 DetailPageFragment를 실행할 때 `add(R.id.fragment_container_view, fragment)`를 사용하면, 
MainPageFragment가 사용자에게 보이지는 않지만 lifecycle이 onResume 상태를 유지하더라구요. 
MainPageFragment를 onPause 상태로 바꾸고 싶은데, 어떻게 할 수 있나요?  

- A1. replace를 사용하시면 됩니다.
add를 하면 기존의 A화면의 라이프 사이클에 영향이 없습니다. 
A화면은 그냥 가려져서 안보일뿐 B화면이 보여짐.
https://pluu.github.io/blog/android/2023/01/19/fragment_visible_lifecycleowner/
이런식으로 lifecycle을 커스텀해볼수는 있음. 

[refactor: Fragment의 MaxLifecycle을 수정해서 상세 화면을 보여줄 때 MainPageFragment가 onPause 상태를 유지하도록 수정](https://github.com/DoTheBestMayB/NBC-AppleMarket/pull/1/commits/c5ba96ae0796295b56cb7ade85456b98f0ad6a03)

---
- Q2. MainPageFragment를 onPause 상태로 바꾸고 싶은 이유는 DetailPageFragment에서 뒤로가기를 누르면 DetailPageFragment가 종료되지 않고, MainPageFragment의 onCreate에서 뒤로가기 버튼에 따라 동작하도록 설정한 코드가 실행되기 때문입니다. </br>
override fun onCreate(savedInstanceState: Bundle?) { 
super.onCreate(savedInstanceState) requireActivity().onBackPressedDispatcher.addCallback(this) { if (isEnabled) { finishDialog.show() } } insertDummyData() } 왜 DetailPageFragment에서 뒤로가기를 누르면 MainPageFragment가 뒤로가기 동작을 체가는 건가요? </br>
공식 문서(https://developer.android.com/guide/navigation/navigation-custom-back)도 읽어봤지만, 내용이 이해가 되지 않습니다. 
공식 문서에서 권장하는 chain of Responsibility에 맞게 구현하려면 뒤로가기 구현 로직을 어떻게 수정해야 할까요? 


- A2. DetailPageFragment에 addcallback 해보세요. </br> DetailPageFragment 에 추가해서 동작을 처리해보시면… </br> 아니면 Activity 단에 하나만 두고 예를들어 current top 화면을 따로 관리해주던지 해서 처리… </br>
```kotlin
requireActivity().onBackPressedDispatcher.addCallback(this) {
    //…
}
```

알려주신 Pluu님 글에 있는 custom한 ViewLifecycleOwner를 back pressed observing에 설정해서 해결했습니다!

[fix: MainPageFragment에 등록된 onBackPressedCallBack의 LifecycleOwner를 Fragment가 아닌 visibleLifecycleOwner로 변경](https://github.com/DoTheBestMayB/NBC-AppleMarket/pull/1/commits/8d1a927b5e2e535d053970e8611425c4c71a3375)

---
- Q3. 4. DetailPageFragment에서 매너 온도 팝업창을 숨기기 위한 ClickListener 질문을 드렸었는데, 
더 나은 방안이 떠오르지 않아, 스크롤 뷰의 setOnTouchListener에서 처리하도록 구현했습니다.

- A3. 지난번 슬랙으로 드린 링크에서… 아래와 같은 코드도 참고
```
override fun dispatchTouchEvent(ev: MotionEvent?): Boolean {
    Log.d("MainAct", "=== dispatchTouchEvent ===")
    if(vTouch.visibility == View.VISIBLE){
        val viewRect = Rect()
        vTouch.getGlobalVisibleRect(viewRect)
        if (!viewRect.contains(ev!!.rawX.toInt(), ev!!.rawY.toInt())) {
            Log.d("dispatchTouchEvent","=== dispatchTouchEvent 포함되어있지 않음 ===")
        }
    }
    super.dispatchTouchEvent(ev)
    return true
}
```
https://stackoverflow.com/questions/6685690/android-make-view-disappear-by-clicking-outside-of-it
https://stackoverflow.com/questions/16155285/how-to-handle-touch-outside-the-view-in-android


MainActivity에서 dispatchTouchEvent 함수에서 Fragment의 tag 값을 이용해 현재 보이고 있는 Fragment가 상세 화면인지 판별하고, 상세 화면이 맞다면, 상세 화면에서 온도 안내 창이 보이는 경우에 한해, 온도 안내 창 외 영역을 클릭한 경우 Visibility를 변경하도록 수정했습니다.

[refactor: dispatchTouchEvent를 이용해 온도 안내 팝업창 visibility 변경](https://github.com/DoTheBestMayB/NBC-AppleMarket/pull/1/commits/186a691585f43757272f98a13de740328be42ee3)